### PR TITLE
[SLICE][#16] strict verb args + parent alias + full thought ingest

### DIFF
--- a/crates/mcp/src/tools_v1/tool_merge.rs
+++ b/crates/mcp/src/tools_v1/tool_merge.rs
@@ -30,6 +30,12 @@ fn handle_into(
     workspace: &str,
     command: &super::markdown::ParsedCommand,
 ) -> Value {
+    if let Err(err) =
+        command.reject_unknown_args(&["target", "from", "strategy", "summary", "message", "body"])
+    {
+        return err;
+    }
+
     let target_branch_id = match command.require_arg("target") {
         Ok(v) => v,
         Err(err) => return err,

--- a/crates/mcp/src/tools_v1/tool_think.rs
+++ b/crates/mcp/src/tools_v1/tool_think.rs
@@ -34,6 +34,12 @@ fn handle_commit(
     workspace: &str,
     command: &super::markdown::ParsedCommand,
 ) -> Value {
+    if let Err(err) =
+        command.reject_unknown_args(&["branch", "commit", "message", "body", "parent"])
+    {
+        return err;
+    }
+
     let branch_id = match command.require_arg("branch") {
         Ok(v) => v,
         Err(err) => return err,
@@ -88,6 +94,10 @@ fn handle_log(
     workspace: &str,
     command: &super::markdown::ParsedCommand,
 ) -> Value {
+    if let Err(err) = command.reject_unknown_args(&["branch", "limit", "offset", "from"]) {
+        return err;
+    }
+
     let branch_id = match command.require_arg("branch") {
         Ok(v) => v,
         Err(err) => return err,
@@ -206,6 +216,10 @@ fn handle_show(
     workspace: &str,
     command: &super::markdown::ParsedCommand,
 ) -> Value {
+    if let Err(err) = command.reject_unknown_args(&["commit"]) {
+        return err;
+    }
+
     let commit_id = match command.require_arg("commit") {
         Ok(v) => v,
         Err(err) => return err,
@@ -232,6 +246,12 @@ fn handle_amend(
     workspace: &str,
     command: &super::markdown::ParsedCommand,
 ) -> Value {
+    if let Err(err) =
+        command.reject_unknown_args(&["commit", "new_commit", "branch", "message", "body"])
+    {
+        return err;
+    }
+
     let source_commit_id = match command.require_arg("commit") {
         Ok(v) => v,
         Err(err) => return err,
@@ -304,6 +324,12 @@ fn handle_delete(
     workspace: &str,
     command: &super::markdown::ParsedCommand,
 ) -> Value {
+    if let Err(err) =
+        command.reject_unknown_args(&["commit", "new_commit", "branch", "message", "body"])
+    {
+        return err;
+    }
+
     let source_commit_id = match command.require_arg("commit") {
         Ok(v) => v,
         Err(err) => return err,

--- a/docs/contracts/V3_MCP_SURFACE.md
+++ b/docs/contracts/V3_MCP_SURFACE.md
@@ -20,6 +20,9 @@ Input is a JSON object:
 
 Unknown top-level keys are rejected with `UNKNOWN_ARG`.
 
+`max_chars` does **not** limit thought payload ingestion/storage.  
+Thought markdown is accepted in full; budgeting applies only to response shaping/transport.
+
 ## Strict parser contract
 
 `markdown` must contain exactly one fenced `bm` block:
@@ -40,12 +43,30 @@ Rules:
 - Tokens after verb must be `key=value`.
 - Duplicate keys are rejected.
 - Unknown verbs are rejected with `UNKNOWN_VERB`.
+- Unknown command arguments are rejected with `UNKNOWN_ARG` (fail-closed; no silent ignore).
 
 ## Tool verbs
 
 - `branch`: `main`, `create`, `list`, `checkout`, `delete`
 - `think`: `commit`, `log`, `show`, `amend`, `delete`
 - `merge`: `into`
+
+### Verb argument contract (strict)
+
+- `branch.main`: _(no args)_
+- `branch.create`: `branch`, optional one of (`from` | `parent`)  
+  (`from` and `parent` together are invalid)
+- `branch.list`: optional `limit`, `offset`
+- `branch.checkout`: `branch`
+- `branch.delete`: `branch`
+
+- `think.commit`: `branch`, `commit`, `message`, optional `body`, `parent`
+- `think.log`: `branch`, optional `limit`, `offset`, `from`
+- `think.show`: `commit`
+- `think.amend`: `commit`, `new_commit`, optional `branch`, `message`, `body`
+- `think.delete`: `commit`, `new_commit`, optional `branch`, `message`, `body`
+
+- `merge.into`: `target`, `from`, optional `strategy`, `summary`, `message`, `body`
 
 ## Error model (typed)
 


### PR DESCRIPTION
Refs #16

## Done
- Added strict per-verb unknown-arg rejection (UNKNOWN_ARG) for think/branch/merge commands.
- branch.create now supports parent alias and rejects from+parent conflict fail-closed.
- Removed markdown-ingest rejection by max_chars: thought payload ingestion is full-fidelity; budget knob remains schema-stable.
- Updated v3 contract and protocol tests for these invariants.

## Verify
- cargo test -p bm_mcp --test mcp_protocol
- cargo test -p bm_mcp
- make check