### PR TITLE
[SLICE][#18] align think.commit optional body contract

### DIFF
--- a/crates/mcp/src/tools_v1/tool_think.rs
+++ b/crates/mcp/src/tools_v1/tool_think.rs
@@ -62,15 +62,8 @@ fn handle_commit(
             } else {
                 Some(command.body.clone())
             }
-        });
-    let Some(body) = body else {
-        return crate::ai_error_with(
-            "INVALID_INPUT",
-            "body is required",
-            Some("Set body=... or provide body text on the second line inside ```bm."),
-            Vec::new(),
-        );
-    };
+        })
+        .unwrap_or_else(|| message.clone());
 
     let parent_commit_id = command.optional_arg("parent").map(ToOwned::to_owned);
     let request = AppendCommitRequest {


### PR DESCRIPTION
Refs #18

## Done
- Aligned `think.commit` with v3 contract where `body` is optional.
- Kept domain fail-closed invariant (`body` persisted non-empty) via deterministic fallback order:
  1) `body=` arg
  2) fenced body text
  3) `message`
- Added protocol tests for no-body and fenced-body-only commit flows.

## Verify
- cargo test -p bm_mcp --test mcp_protocol
- make check
