### PR TITLE
[SLICE][#20] add shared-reset mode for daemon/socket hygiene

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check clippy test check run-mcp
+.PHONY: help fmt fmt-check clippy test check run-mcp shared-reset
 
 CARGO ?= cargo
 
@@ -11,6 +11,7 @@ help:
 		"  make clippy     Run clippy (deny warnings)" \
 		"  make test       Run workspace tests" \
 		"  make run-mcp    Run MCP server (DX defaults)" \
+		"  make shared-reset  Reset current shared socket (best-effort daemon shutdown + stale socket cleanup)" \
 		""
 
 fmt:
@@ -30,3 +31,6 @@ check: fmt-check clippy test
 # Golden path: zero-arg run enables DX defaults.
 run-mcp:
 	$(CARGO) run -p bm_mcp
+
+shared-reset:
+	$(CARGO) run -p bm_mcp -- --shared-reset

--- a/docs/runbooks/LOCAL_DEV.md
+++ b/docs/runbooks/LOCAL_DEV.md
@@ -48,21 +48,18 @@ These files never include request bodies, only minimal metadata.
 
 ## Cleanup stray processes / sockets
 
-If you see many leftover `bm_mcp` processes (e.g., after a crashed TUI session), do a hard reset:
+Use the built-in shared reset command (same socket config resolution as normal startup):
 
 ```bash
-pkill -TERM -x bm_mcp || true
-sleep 0.2
-pkill -KILL -x bm_mcp || true
-
-# Optional: clear shared-mode runtime sockets (safe; they are recreated on demand).
-rm -f "${XDG_RUNTIME_DIR:-/tmp}/branchmind_mcp"/*.sock 2>/dev/null || true
+make shared-reset
 ```
 
 Notes:
 
-- Seeing a few `[bm_mcp] <defunct>` entries usually means an old parent process hasn’t reaped children yet; restarting that parent (or rebooting) clears them.
-- Repo-local socket files under `.agents/mcp/.branchmind/*.sock` are safe to delete.
+- `--shared-reset` does **not** start stdio/shared/daemon loops; it only does best-effort daemon shutdown + stale socket unlink and prints a compact JSON report.
+- `--shared-reset` by itself keeps the same auto defaults as zero-arg `make run-mcp`, so it targets the same default shared socket tag/path.
+- If your client uses non-default flags/env (`--storage-dir`, `--toolset`, workspace/project guard), run the reset command with the same config so it targets the same socket.
+- Global process-kill snippets should be kept as last-resort OS-level recovery only.
 
 ## Codex config (recommended)
 


### PR DESCRIPTION
Refs #20

## Done
- Added `bm_mcp --shared-reset` mode (unix) for deterministic shared-daemon/socket cleanup.
- Reset mode does not start stdio/shared/daemon loops; it performs best-effort daemon shutdown and stale socket unlink, then exits with compact JSON report.
- Added runtime parser support + tests, including auto-default alignment for `--shared-reset` (same default socket tag/path as zero-arg run).
- Added `make shared-reset` and updated local-dev runbook.

## Verify
- cargo test -p bm_mcp
- make check
- cargo run -p bm_mcp -- --shared-reset
