### PR TITLE
slice35: cosmetic cleanup of residual legacy wording

### DIFF
--- a/crates/mcp/src/server/lifecycle.rs
+++ b/crates/mcp/src/server/lifecycle.rs
@@ -184,8 +184,8 @@ impl McpServer {
     }
 
     pub(crate) fn call_tool(&mut self, name: &str, args: Value) -> Value {
-        // v3: only the 3 advertised markdown tools are callable. Legacy names are rejected
-        // fail-closed.
+        // v3: only the 3 advertised markdown tools are callable. Unsupported or removed names
+        // are rejected fail-closed.
         if !crate::tools::is_supported_tool(name) {
             return crate::ai_error_with(
                 "UNKNOWN_TOOL",

--- a/crates/mcp/tests/tool_dispatch_guard.rs
+++ b/crates/mcp/tests/tool_dispatch_guard.rs
@@ -39,7 +39,7 @@ fn tools_list_exposes_only_v3_markdown_surface() {
 fn unknown_tools_fail_closed() {
     let mut server = Server::start_initialized_with_args("v3_surface_unknown_tool", &[]);
 
-    let legacy = server.request(json!({
+    let unsupported_tool = server.request(json!({
         "jsonrpc": "2.0",
         "id": 2,
         "method": "tools/call",
@@ -48,12 +48,16 @@ fn unknown_tools_fail_closed() {
             "arguments": {}
         }
     }));
-    let payload = extract_tool_text(&legacy);
+    let payload = extract_tool_text(&unsupported_tool);
     let code = payload
         .get("error")
         .and_then(|v| v.get("code"))
         .and_then(|v| v.as_str());
-    assert_eq!(code, Some("UNKNOWN_TOOL"), "legacy tool must fail-closed");
+    assert_eq!(
+        code,
+        Some("UNKNOWN_TOOL"),
+        "unsupported tool must fail-closed"
+    );
 }
 
 #[test]

--- a/docs/contracts/INTEGRATION.md
+++ b/docs/contracts/INTEGRATION.md
@@ -29,5 +29,5 @@ This document defines how `branch`, `think`, and `merge` compose into one determ
 
 ## Out of scope
 
-- Legacy multi-portal surfaces and alias tools.
+- Removed multi-portal surfaces and non-current alias tools.
 - Non-markdown tool inputs.

--- a/docs/contracts/PARITY.md
+++ b/docs/contracts/PARITY.md
@@ -14,6 +14,6 @@ v3 parity target is intentionally minimal and strict.
 
 ## Explicitly removed from parity target
 
-- Legacy portal surfaces (`tasks`, `jobs`, `system`, etc.)
-- Legacy alias tool names from v1/v2 migration eras
+- Removed non-current portal surfaces (`tasks`, `jobs`, `system`, etc.)
+- Removed alias tool names outside the current v3 surface
 - Non-markdown command modes

--- a/docs/contracts/V3_MCP_SURFACE.md
+++ b/docs/contracts/V3_MCP_SURFACE.md
@@ -8,7 +8,7 @@
 - `branch`
 - `merge`
 
-Legacy tool names are fail-closed with `UNKNOWN_TOOL`.
+Unsupported or removed tool names are fail-closed with `UNKNOWN_TOOL`.
 
 ## Shared input contract
 


### PR DESCRIPTION
## Summary
Text-only polish after reasoning-only cut:
- replaced residual legacy wording near v3 tool surface with neutral unsupported/removed wording
- kept behavior unchanged

## Scope
Implements #35.

## Files
- crates/mcp/src/server/lifecycle.rs
- crates/mcp/tests/tool_dispatch_guard.rs
- docs/contracts/V3_MCP_SURFACE.md
- docs/contracts/PARITY.md
- docs/contracts/INTEGRATION.md

## Validation
- make check
